### PR TITLE
Handle warnings from assembly attributes added with TFM target platforms

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Data.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Data.cs
@@ -24,12 +24,29 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         /// </summary>
         private class PlatformAttributes
         {
-            public Version? SupportedFirst { get; set; }
-            public Version? SupportedSecond { get; set; }
-            public Version? UnsupportedFirst { get; set; }
-            public Version? UnsupportedSecond { get; set; }
+            public VersionAndLevel? SupportedFirst { get; set; }
+            public VersionAndLevel? SupportedSecond { get; set; }
+            public VersionAndLevel? UnsupportedFirst { get; set; }
+            public VersionAndLevel? UnsupportedSecond { get; set; }
             public bool HasAttribute() => SupportedFirst != null || UnsupportedFirst != null ||
                         SupportedSecond != null || UnsupportedSecond != null;
+        }
+
+        private class VersionAndLevel
+        {
+            public Version Version { get; set; }
+            public bool Assembly { get; set; }
+
+            public VersionAndLevel(Version version, bool assemblyLevel)
+            {
+                Version = version;
+                Assembly = assemblyLevel;
+            }
+
+            internal VersionAndLevel Clone()
+            {
+                return new VersionAndLevel((Version)Version.Clone(), Assembly);
+            }
         }
     }
 }


### PR DESCRIPTION
The PR handles 2 types of warning scenarios:
1. Assembly attribute causing warnings within Unsupported context. For this scenario was need to distinguish assembly attribute from immediate member attribute
```csharp
// UnsupportedContextReferencedApiWithinSameAssemblyAttributeNotWarn()
[assembly:SupportedOSPlatform("Browser")] // Attribute from TFM target, can be ignored
public class Test
{
    private string program;
    [UnsupportedOSPlatform("browser)]
    public string CurrentProgram
    {
        get
        {
            return program; // should not warn
        }
    }
}

// UnsupportedContextReferencedApiWithinSameAssemblyPlusImmediateAttributeWarns()
[assembly:SupportedOSPlatform("Browser")] // Attribute from TFM target, can be ignored
public class Test
{
    [SupportedOSPlatform("Browser")] // Real platform dependency can be applied
    private static string s_program;
	
    [UnsupportedOSPlatform("browser")]
    public static string CurrentProgram
    {
        get
        {
            return s_program; // should warn
        }
    }
}

// UnsupportedContextReferencedPCApiFromDifferentAssemblyWarns()
[assembly:SupportedOSPlatform("Windows")] // Attribute from TFM target, can be ignored
public class Test
{
    [UnsupportedOSPlatform("windows")]
    public void Beep(int frequency, int duration)
    {
        Console.Beep(frequency, duration); // Windows only API from different assembly, should still warn
    }
}
```
2. Child attribute can narrow parent support of multiple platforms
```csharp
// ChildCanNarrowUpperLevelSupportedPlatforms()
[assembly:SupportedOSPlatform("windows")]
[assembly:SupportedOSPlatform("ios")]
public class Test
{
    [SupportedOSPlatform("windows7.0")]
    private void WindowsOnly() { }
    [SupportedOSPlatform("ios"")]
    private void IosOnly () { }
	
    public void M1 () // Both should warn
    {
        WindowsOnly();
        IosOnly();
    }
    [SupportedOSPlatform("Windows")]
    public void M2 ()
    {
        WindowsOnly(); // not warn
        IosOnly();     // warn
    }
    [SupportedOSPlatform("iOS")]
    public void M3 ()
    {
        WindowsOnly(); // warn
        IosOnly();     // not warn
    }
}
``` 